### PR TITLE
freeze render methods to avoid duplicate methods be renamed

### DIFF
--- a/src/vueTransform.js
+++ b/src/vueTransform.js
@@ -3,7 +3,7 @@ import MagicString from 'magic-string'
 import { resolve } from 'path'
 import { readFileSync } from 'fs'
 
-export default function vueTransform (code, id) {
+export default function vueTransform (code, id, scripts) {
   const nodes = compiler.parseComponent(code)
   const s = new MagicString(code)
   let exportOffset = 0
@@ -31,7 +31,7 @@ export default function vueTransform (code, id) {
 
   // Precompile and inject Vue template
   if (nodes.template) {
-    injectTemplate(s, nodes.template, exportOffset, id)
+    scripts[id] = injectTemplate(s, nodes.template, exportOffset, id)
   }
 
   // Import css as a module
@@ -92,7 +92,10 @@ function injectTemplate (s, node, offset, id) {
   // Inject render function
   // Replace "with(this){" with something that works in strict mode
   // https://github.com/vuejs/vue-template-es2015-compiler/blob/master/index.js
-  s.insertLeft(offset, renderFuncs.replace(/with\(this\)/g, 'if(window.__VUE_WITH__)'))
+  s.insertLeft(offset, '__VUE_ID__:' + JSON.stringify(id) + ',')
+  // s.insertLeft(offset, renderFuncs.replace(/with\(this\)/g, 'if(window.__VUE_WITH__)'))
+
+  return renderFuncs
 }
 
 /**

--- a/test/expects/WithoutRollupRender.js
+++ b/test/expects/WithoutRollupRender.js
@@ -1,0 +1,25 @@
+function method() {
+	console.log('method');
+}
+function noop() {
+	method();
+}
+
+function method$1() {
+	noop$1();
+}
+function noop$1() {
+	console.log('noop');
+}
+
+noop();
+	var WithoutRollupRender = {
+render: function(){with(this){return _h('span',{on:{"click":method}},["METHOD"])}},
+staticRenderFns: [],
+		methods: {
+			method: method$1,
+			noop
+		}
+	};
+
+export default WithoutRollupRender;

--- a/test/fixtures/WithoutRollupRender.vue
+++ b/test/fixtures/WithoutRollupRender.vue
@@ -1,0 +1,14 @@
+<template>
+	<span @click="method">METHOD</span>
+</template>
+<script type="text/javascript">
+	import {noop} from './WithoutRollupRenderMethod2'
+	import {method} from './WithoutRollupRenderMethod'
+	noop()
+	export default {
+		methods: {
+			method,
+			noop
+		}
+	}
+</script>

--- a/test/fixtures/WithoutRollupRenderMethod.js
+++ b/test/fixtures/WithoutRollupRenderMethod.js
@@ -1,0 +1,6 @@
+export function method() {
+	noop()
+}
+export function noop() {
+	console.log('noop')
+}

--- a/test/fixtures/WithoutRollupRenderMethod2.js
+++ b/test/fixtures/WithoutRollupRenderMethod2.js
@@ -1,0 +1,6 @@
+export function method() {
+	console.log('method')
+}
+export function noop() {
+	method()
+}

--- a/test/test.js
+++ b/test/test.js
@@ -91,6 +91,14 @@ describe('rollup-plugin-vue2', function () {
     })
   })
 
+  it('should not rollup render methods', function () {
+    return simpleRollup('WithoutRollupRender.vue').then(function (bundle) {
+      var result = bundle.generate()
+      var expected = read('expects/WithoutRollupRender.js')
+      assertEqualFile(result.code, expected)
+    })
+  })
+
   // it('should fail to bundle components with template tag & render function', function () {
   //   assert.throws(
   //     () => simpleRollup('ConflictRender.vue'),


### PR DESCRIPTION
The code of render methods may be renamed, so we should freeze it, and also strict mode option is ok.