### PR TITLE
add vue.runtime.common.js judge

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -20,7 +20,7 @@ export default function vue2 (options = {}) {
       }
     },
     transform (code, id) {
-      if (id.endsWith('vue.common.js')) {
+      if (id.endsWith('vue.common.js') || id.endsWith('vue.runtime.common.js')) {
         return vueCommon(code)
       }
       if (!filter(id)) {


### PR DESCRIPTION
`vue-template-compiler@2.1.3`  match   `vue@2.1.3`

```
{
  "name": "vue",
  "version": "2.1.3",
  "description": "Reactive, component-oriented view layer for modern web interfaces.",
  "main": "dist/vue.runtime.common.js",
```